### PR TITLE
Update href casing to try and fix deployment bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <link rel="stylesheet" href="./css/styles.css">
+  <link rel="stylesheet" href="./CSS/styles.css">
   <title>Bald Eagles - The Game!</title>
 </head>
 <body>


### PR DESCRIPTION
## What does this PR do?

- Attempts to fix issue with custom CSS not appearing on deployed site. Research showed many references to issues with case mismatches between CSS folder and href in link to css file. When testing locally case mismatches in folder names are not an issue, but GitHub pages uses Unix, which does consider case for folder names.

## How should it be tested in the UI?

- Merge this small update to main and let the site deploy. Then check baldeagles.com and ensure the custom CSS displays as expected.
